### PR TITLE
Use common header and footer templates

### DIFF
--- a/data/about.html
+++ b/data/about.html
@@ -2,34 +2,34 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>About RickView {cargo_pkg_version}</title>
+    <title>About RickView {config.cargo_pkg_version}</title>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <link rel="stylesheet" href="rickview.css" type="text/css" />
     <link rel="stylesheet" href="roboto.css" type="text/css" />
     <link rel="shortcut icon" href="favicon.ico" />
-    {{ if css }}<style>{css | unescaped}</style>{{ endif }}
+    {{ if config.css }}<style>{config.css | unescaped}</style>{{ endif }}
   </head>
   <body>
     <article>
       <header>
         <hgroup>
-          <h1>About RickView {cargo_pkg_version}</h1>
+          <h1>About RickView {config.cargo_pkg_version}</h1>
         </hgroup>
         <div id="abstract">
         </div>
         <aside class="empty"></aside>
         <div id="directs">
           <ul>
-			<li>title index {num_titles} entries with size {titles_size}</li>
-			<li>type index {num_types} entries with size {types_size}</li>
-			<li>graph size {graph_size}</li>
+           <li>title index {about.num_titles} entries with size {about.titles_size}</li>
+           <li>type index {about.num_types} entries with size {about.types_size}</li>
+           <li>graph size {about.graph_size}</li>
           </ul>
         </div>
       </header>
     </article>
     <footer>
       <div id="footer-left">
-        <p><a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {cargo_pkg_version}</a></p>
+        <p><a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {config.cargo_pkg_version}</a></p>
         <p><a href="about" class="uppercase">graph stats</a></p>
       </div>
       <div id="footer-right">

--- a/data/about.html
+++ b/data/about.html
@@ -1,14 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>About RickView {config.cargo_pkg_version}</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1"/>
-    <link rel="stylesheet" href="rickview.css" type="text/css" />
-    <link rel="stylesheet" href="roboto.css" type="text/css" />
-    <link rel="shortcut icon" href="favicon.ico" />
-    {{ if config.css }}<style>{config.css | unescaped}</style>{{ endif }}
-  </head>
+{{ call header with config}}
   <body>
     <article>
       <header>
@@ -27,13 +17,4 @@
         </div>
       </header>
     </article>
-    <footer>
-      <div id="footer-left">
-        <p><a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {config.cargo_pkg_version}</a></p>
-        <p><a href="about" class="uppercase">graph stats</a></p>
-      </div>
-      <div id="footer-right">
-      </div>
-    </footer>
-  </body>
-</html>
+{{ call footer with config}}

--- a/data/default.toml
+++ b/data/default.toml
@@ -14,6 +14,10 @@ subtitle = "You have successfully installed RickView but not configured a knowle
 log_level = "info"
 show_inverse = true
 large = false
+[header]
+title = "test title"
+subtitle = "test subtitle"
+css = "test css"
 [namespaces]
 rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 rdfs = "http://www.w3.org/2000/01/rdf-schema#"

--- a/data/footer.html
+++ b/data/footer.html
@@ -1,0 +1,13 @@
+    <footer>
+      <div id="footer-left">
+        <p><a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {cargo_pkg_version}</a></p>
+        <p><a href="about" class="uppercase">graph stats</a></p>
+      </div>
+      <div id="footer-right">
+        <ul>
+          <li>{{if github}}<a target="_blank" href="{github}/issues">view issues about the knowledge base on GitHub</a>{{ endif }}</li>
+        </ul>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/data/header.html
+++ b/data/header.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<link rel="stylesheet" href="rickview.css" type="text/css" />
+		<link rel="stylesheet" href="roboto.css" type="text/css" />
+		<link rel="shortcut icon" href="favicon.ico" />
+		<title>{title}</title>
+	</head>

--- a/data/header.html
+++ b/data/header.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<link rel="stylesheet" href="rickview.css" type="text/css" />
-		<link rel="stylesheet" href="roboto.css" type="text/css" />
-		<link rel="shortcut icon" href="favicon.ico" />
-		<title>{title}</title>
-	</head>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="stylesheet" href="rickview.css" type="text/css" />
+    <link rel="stylesheet" href="roboto.css" type="text/css" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <title>{title}</title>
+    {{ if css }}<style>{css | unescaped}</style>{{ endif }}
+  </head>

--- a/data/index.html
+++ b/data/index.html
@@ -1,17 +1,15 @@
-{{ call header with header}}
-    {{ if css }}<style>{css | unescaped}</style>{{ endif }}
-  </head>
+{{ call header with config}}
   <body>
     <article>
       <header>
         <hgroup>
-          <h1>{title}</h1>
-          <h2>{subtitle}</h2>
+          <h1>{config.title}</h1>
+          <h2>{config.subtitle}</h2>
         </hgroup>
         <div id="abstract">
-          {{ if examples }} Examples:
+          {{ if config.examples }} Examples:
           <ul>
-            {{ for c in examples }}
+            {{ for c in config.examples }}
             <li><a href="{c}">{c}</a></li>
             {{ endfor }}
           </ul>
@@ -19,26 +17,14 @@
         </div>
         <aside class="empty"></aside>
         <div id="directs">
-          {{ if body }}<div id="custom">{ body | unescaped }</div>{{ endif }}
+          {{ if config.body }}<div id="custom">{ config.body | unescaped }</div>{{ endif }}
           See also:
           <ul>
-            {{ if homepage }}<li><a href="{homepage}">Homepage</a></li>{{ endif }}
-            {{ if endpoint }}<li><a href="{endpoint}">SPARQL Endpoint</a></li>{{ endif }}
-            {{ if doc }}<li><a href="{doc}">Documentation</a></li>{{ endif }}
+            {{ if config.homepage }}<li><a href="{config.homepage}">Homepage</a></li>{{ endif }}
+            {{ if config.endpoint }}<li><a href="{config.endpoint}">SPARQL Endpoint</a></li>{{ endif }}
+            {{ if config.doc }}<li><a href="{config.doc}">Documentation</a></li>{{ endif }}
           </ul>
         </div>
       </header>
     </article>
-    <footer>
-      <div id="footer-left">
-        <p><a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {cargo_pkg_version}</a></p>
-        <p><a href="about" class="uppercase">graph stats</a></p>
-      </div>
-      <div id="footer-right">
-        <ul>
-          <li>{{if github}}<a target="_blank" href="{github}/issues">view issues about the knowledge base on GitHub</a>{{ endif }}</li>
-        </ul>
-      </div>
-    </footer>
-  </body>
-</html>
+{{ call footer with config}}

--- a/data/index.html
+++ b/data/index.html
@@ -1,13 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>{title}</title>
-    <base href="{base}/">
-    <link rel="stylesheet" href="rickview.css" type="text/css" />
-    <link rel="stylesheet" href="roboto.css" type="text/css" />
-    <link rel="shortcut icon" href="favicon.ico" />
+{{ call header with header}}
     {{ if css }}<style>{css | unescaped}</style>{{ endif }}
   </head>
   <body>
@@ -32,8 +23,8 @@
           See also:
           <ul>
             {{ if homepage }}<li><a href="{homepage}">Homepage</a></li>{{ endif }}
-			{{ if endpoint }}<li><a href="{endpoint}">SPARQL Endpoint</a></li>{{ endif }}
-			{{ if doc }}<li><a href="{doc}">Documentation</a></li>{{ endif }}
+            {{ if endpoint }}<li><a href="{endpoint}">SPARQL Endpoint</a></li>{{ endif }}
+            {{ if doc }}<li><a href="{doc}">Documentation</a></li>{{ endif }}
           </ul>
         </div>
       </header>

--- a/data/resource.html
+++ b/data/resource.html
@@ -1,37 +1,23 @@
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width,initial-scale=1" />
-		<title>{title}</title>
-		<link rel="stylesheet" href="rickview.css" type="text/css" />
-		<link rel="stylesheet" href="roboto.css" type="text/css" />
-		<link rel="shortcut icon" href="favicon.ico" />
-		{{- if css }}
-		<style>
-			{css | unescaped}
-		</style>
-		{{- endif }}
-	</head>
+{{ call header with config}}
 	<body>
 		<article>
 			<header>
 				<hgroup>
-					<h1>{title }</h1>
-					{{- if depiction }}<img class="depiction" src="{ depiction }" />{{ endif }}
-					<h2> {uri}
-						{{- if main_type }}
+					<h1>{resource.title }</h1>
+					{{- if resource.depiction }}<img class="depiction" src="{ resource.depiction }" />{{ endif }}
+					<h2> {resource.uri}
+						{{- if resource.main_type }}
 						<span class="instance">
-							<a title="<{main_type}>" href="{main_type}" target="_blank">
+							<a title="<{resource.main_type}>" href="{resource.main_type}" target="_blank">
 								<span class="instanceof">an entity of type:</span>
-								<span>{ main_type | uri_to_suffix }</span>
+								<span>{ resource.main_type | uri_to_suffix }</span>
 							</a>
 						</span>
 					{{ endif }}</h2>
 				</hgroup>
 				<div id="abstract">
 					<table>
-						{{- for entry in descriptions }}
+						{{- for entry in resource.descriptions }}
 						<tr>
 							<td class="td1">
 								<label class="c1">{ entry.0 | unescaped }</label>
@@ -49,7 +35,7 @@
 				<aside class="empty"></aside>
 				<div id="directs">
 					<table>
-						{{- for entry in directs }}
+						{{- for entry in resource.directs }}
 						<tr>
 							<td class="td1">
 								<label class="c1">{ entry.0 | unescaped }</label>
@@ -69,7 +55,7 @@
 			<div id="inverses">
 				<h3>inverse relations</h3>
 				<table>
-					{{- for entry in inverses }}
+					{{- for entry in resource.inverses }}
 					<tr>
 						<td class="td1">
 							<label class="c1">is { entry.0 | unescaped } of</label>
@@ -88,10 +74,10 @@
 		<footer>
 			<div id="footer-left">
 				<p>
-					<a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {cargo_pkg_version}</a>
+					<a href="https://github.com/konradhoeffner/rickview" class="uppercase" target="_blank" title="based on RickView">RickView {config.cargo_pkg_version}</a>
 				</p>
 				<p><a href="about" class="uppercase">graph stats</a></p>
-				<p>{duration}</p>
+				<p>{resource.duration}</p>
 			</div>
 			<div id="footer-right">
 				<ul>
@@ -101,14 +87,14 @@
 						<a href="?output=application/n-triples">ntriples,</a>
 						<a href="?output=application/turtle">turtle</a>
 					</li>
-					{{- if github_issue_url }}
+					{{- if resource.github_issue_url }}
 					<li>
-						<a target="_blank" href="{github_issue_url}">create issue about this resource on GitHub</a>
+						<a target="_blank" href="{resource.github_issue_url}">create issue about this resource on GitHub</a>
 					</li>
 					{{- endif }}
 					<li>
-						{{if github}}
-						<a target="_blank" href="{github}/issues">view issues about the knowledge base on GitHub</a>
+						{{if config.github}}
+						<a target="_blank" href="{config.github}/issues">view issues about the knowledge base on GitHub</a>
 						{{- endif }}
 					</li>
 				</ul>

--- a/data/resource.html
+++ b/data/resource.html
@@ -65,7 +65,7 @@
 							{{- for value in entry.1 }} {{ if not @first }}
 							{{- endif }}
 							<span class="c2">{ value | unescaped }</span>
-							{{- endfor }}
+							{{- endfor }}Bone
 						</td>
 					</tr>
 					{{- endfor }}
@@ -94,11 +94,11 @@
 						<a target="_blank" href="{resource.github_issue_url}">create issue about this resource on GitHub</a>
 					</li>
 					{{- endif }}
+					{{if config.github}}
 					<li>
-						{{if config.github}}
 						<a target="_blank" href="{config.github}/issues">view issues about the knowledge base on GitHub</a>
-						{{- endif }}
 					</li>
+					{{- endif }}
 				</ul>
 			</div>
 		</footer>

--- a/data/resource.html
+++ b/data/resource.html
@@ -52,6 +52,7 @@
 				</div>
 			</header>
 			<aside class="empty"></aside>
+			{{- if resource.inverses }}
 			<div id="inverses">
 				<h3>inverse relations</h3>
 				<table>
@@ -70,6 +71,7 @@
 					{{- endfor }}
 				</table>
 			</div>
+			{{- endif }}
 		</article>
 		<footer>
 			<div id="footer-left">

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 impl Config {
     pub fn new() -> Result<Self, ConfigError> {
+        // configuration precedence: env var > config key > default value
+        // namespaces cannot be configured with env vars
         let mut config: Config = config::Config::builder()
             .add_source(File::from_str(DEFAULT, FileFormat::Toml))
             .add_source(File::new("data/config.toml", FileFormat::Toml).required(false))
@@ -93,7 +95,7 @@ impl Config {
         if config.base.ends_with('/') {
             config.base.pop();
         }
-        // log level precedence: env var > config key > default value
+        // initialize logging here because we want it as early as possible but we need the log level
         let mut binding = env_logger::Builder::new();
         let builder = match std::env::var("RUST_LOG") {
             Err(_) => binding.filter(
@@ -105,6 +107,7 @@ impl Config {
 
         let _ = builder.format_timestamp(None).format_target(false).try_init();
 
+        // optional custom HTML included only in the index.html template
         // path relative to executable
         match std::fs::File::open("data/body.html") {
             Ok(body_file) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,12 +8,6 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Header {
-    pub title: Option<String>,
-    pub subtitle: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     /// Server-side common path prefix (scope) that normally matches the last part of the namespace but may also be "" e.g. for local testing.
     /// For example, port 8080, empty base (default) and namespace <http://ab.com/d/> would serve <http://ab.com/d/X> at <localhost:8080/X>.
@@ -21,7 +15,6 @@ pub struct Config {
     /// Don't use a trailing slash, it will be removed.
     /// See also <https://docs.rs/actix-web/latest/actix_web/struct.Scope.html>.
     pub base: String,
-    pub header: Header,
     pub title: Option<String>,
     pub subtitle: Option<String>,
     pub kb_file: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,12 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct Header {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     /// Server-side common path prefix (scope) that normally matches the last part of the namespace but may also be "" e.g. for local testing.
     /// For example, port 8080, empty base (default) and namespace <http://ab.com/d/> would serve <http://ab.com/d/X> at <localhost:8080/X>.
@@ -15,6 +21,7 @@ pub struct Config {
     /// Don't use a trailing slash, it will be removed.
     /// See also <https://docs.rs/actix-web/latest/actix_web/struct.Scope.html>.
     pub base: String,
+    pub header: Header,
     pub title: Option<String>,
     pub subtitle: Option<String>,
     pub kb_file: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tinytemplate::TinyTemplate;
 
+static HEADER: &str = std::include_str!("../data/header.html");
 static RESOURCE: &str = std::include_str!("../data/resource.html");
 static FAVICON: &[u8; 318] = std::include_bytes!("../data/favicon.ico");
 // extremely low risk of collision, worst case is out of date favicon or CSS
@@ -57,6 +58,7 @@ static ROBOTO_CSS_SHASH_QUOTED: LazyLock<String> = LazyLock::new(|| format!("\"{
 
 fn template() -> TinyTemplate<'static> {
     let mut tt = TinyTemplate::new();
+    tt.add_template("header", HEADER).expect("Could not parse header template");
     tt.add_template("resource", RESOURCE).expect("Could not parse resource page template");
     tt.add_template("index", INDEX).expect("Could not parse index page template");
     tt.add_template("about", ABOUT).expect("Could not parse about page template");

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ async fn rdf_resource(r: HttpRequest, suffix: web::Path<String>, params: web::Qu
                 if accept.contains(HTML) {
                     res.descriptions.push(("Warning".to_owned(), vec![warning.clone()]));
                     // HTML is accepted and there are no errors, create a pseudo element in the empty resource to return 404 with HTML
-                    return match template().render("resource", &res) {
+                    return match template().render("resource", &Context { config: config(), resource: Some(res), about: None }) {
                         Ok(html) => HttpResponse::NotFound().content_type("text/html; charset-utf-8").append_header(etag).body(add_hashes(&html)),
                         Err(e) => HttpResponse::NotFound().content_type("text/plain").append_header(etag).body(format!("{warning}\n\n{e}")),
                     };
@@ -227,8 +227,6 @@ fn index() -> HttpResponse {
 
 #[get("/about")]
 async fn about_page() -> impl Responder {
-    //let mut config_json = serde_json::to_value(config()).unwrap();
-    //merge(&mut config_json, &serde_json::to_value(About::new()).unwrap());
     let context = Context { config: config(), about: Some(About::new()), resource: None };
     match template().render("about", &context) {
         Ok(body) => HttpResponse::Ok().content_type("text/html").body(add_hashes(&body)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tinytemplate::TinyTemplate;
 
 static HEADER: &str = std::include_str!("../data/header.html");
+static FOOTER: &str = std::include_str!("../data/footer.html");
 static RESOURCE: &str = std::include_str!("../data/resource.html");
 static FAVICON: &[u8; 318] = std::include_bytes!("../data/favicon.ico");
 // extremely low risk of collision, worst case is out of date favicon or CSS
@@ -66,6 +67,7 @@ struct Context {
 fn template() -> TinyTemplate<'static> {
     let mut tt = TinyTemplate::new();
     tt.add_template("header", HEADER).expect("Could not parse header template");
+    tt.add_template("footer", FOOTER).expect("Could not parse footer template");
     tt.add_template("resource", RESOURCE).expect("Could not parse resource page template");
     tt.add_template("index", INDEX).expect("Could not parse index page template");
     tt.add_template("about", ABOUT).expect("Could not parse about page template");
@@ -216,7 +218,8 @@ async fn rdf_resource(r: HttpRequest, suffix: web::Path<String>, params: web::Qu
 
 /// does not get shown when there is a resource whose URI equals the namespace, with or without slash
 fn index() -> HttpResponse {
-    match template().render("index", config()) {
+    let context = Context { config: config(), about: None, resource: None };
+    match template().render("index", &context) {
         Ok(body) => HttpResponse::Ok().content_type("text/html").body(add_hashes(&body)),
         Err(e) => error_response("index page", e),
     }


### PR DESCRIPTION
Still to do: get rid off the pseudo resource element when a resource is not found. 
Update: Not needed right now, change that later in case we need more custom message pages. 